### PR TITLE
Fixed win10 cannot handle EventSource Response

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -87,6 +87,7 @@ function createEventStream(heartbeat) {
         // While behind nginx, event stream should not be buffered:
         // http://nginx.org/docs/http/ngx_http_proxy_module.html#proxy_buffering
         'X-Accel-Buffering': 'no',
+        'Content-Length': '-1'
       };
 
       var isHttp1 = !(parseInt(req.httpVersion) >= 2);


### PR DESCRIPTION
Issue: on Window 10, browsers would not process (or cannot handle) the EventSource's HTTP response if the response is without 'Content-Length'. But hot-middleware is using the streaming data approach to achieve eventsource. So, adding the Response Header 'Content-Length: -1' can solve the problem.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
on Window 10, browsers would not process (or cannot handle) the EventSource's HTTP response if the response is without 'Content-Length'. But hot-middleware is using the streaming data approach to achieve eventsource. So, adding the Response Header 'Content-Length: -1' can solve the problem.

https://github.com/webpack-contrib/webpack-hot-middleware/issues/101
### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
